### PR TITLE
Add cart tracking events

### DIFF
--- a/snippets/product-information.liquid
+++ b/snippets/product-information.liquid
@@ -460,6 +460,43 @@
      
 </div>
 
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var productDataEl = document.getElementById('ProductJson-{{ section.id }}');
+    var productData = productDataEl ? JSON.parse(productDataEl.textContent) : null;
+    var forms = document.querySelectorAll('#shopify-section-{{ section.id }} form[data-product-form]');
+
+    function getVariant(id) {
+      if (!productData) return null;
+      return productData.variants.find(function(v) { return v.id == Number(id); });
+    }
+
+    function sendEvent(eventName, variantId) {
+      var variant = getVariant(variantId);
+      var payload = { content_type: 'product', content_ids: [variantId] };
+      if (variant) {
+        payload.value = variant.price / 100;
+        if (window.Shopify && Shopify.currency && Shopify.currency.active)
+          payload.currency = Shopify.currency.active;
+      }
+      if (typeof fbq === 'function') fbq('track', eventName, payload);
+      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track(eventName, payload);
+    }
+
+    forms.forEach(function(form) {
+      form.addEventListener('submit', function() {
+        var variantId = form.querySelector('[name="id"]').value;
+        sendEvent('AddToCart', variantId);
+      });
+    });
+
+    if (forms.length) {
+      var initialVariantId = forms[0].querySelector('[name="id"]').value;
+      sendEvent('ViewContent', initialVariantId);
+    }
+  });
+</script>
+
 
 
                       

--- a/snippets/site-template.liquid
+++ b/snippets/site-template.liquid
@@ -701,10 +701,11 @@
         </div>
       </div>
       <a href="#ajaxcart__gift" class="collapse-backdrop position-absolute" data-bs-toggle="collapse"  role="button" aria-expanded="false" aria-controls="ajaxcart__gift"></a>
-    {% endif %}
+{% endif %}
   </div>
 {%- endif -%}
 </script>
+
 <script id="quickview-template" type="text/template">
     <div class="product-quickview position-relative">
         <div class="product-quickview__images position-relative">
@@ -992,4 +993,28 @@
       </div>
     </form>
   </div>
+</script>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.body.addEventListener('submit', function (e) {
+      var form = e.target.closest('form[data-product-form]');
+      if (!form) return;
+      var variantField = form.querySelector('[name="id"]');
+      if (!variantField) return;
+      var variantId = variantField.value;
+      var variant = null;
+      if (window.meta && window.meta.product && Array.isArray(window.meta.product.variants)) {
+        variant = window.meta.product.variants.find(function(v) { return v.id == Number(variantId); });
+      }
+      var payload = { content_type: 'product', content_ids: [variantId] };
+      if (variant) {
+        payload.value = variant.price / 100;
+        if (window.Shopify && Shopify.currency && Shopify.currency.active)
+          payload.currency = Shopify.currency.active;
+      }
+      if (typeof fbq === 'function') fbq('track', 'AddToCart', payload);
+      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToCart', payload);
+    });
+  });
 </script>


### PR DESCRIPTION
## Summary
- attach event listeners for product form submissions
- send Facebook and TikTok AddToCart events with variant data
- fire ViewContent events on product page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b2a87ba048324890ffd9eac8cbc04