### PR TITLE
Add order status tracking snippet

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -100,6 +100,7 @@
   });
 </script>
 
+
       
 <!-- chat shopify -->
 {{ content_for_footer }}
@@ -201,11 +202,8 @@
   document.addEventListener("DOMContentLoaded", esperarBundles);
 })();
 </script>
-    
 
-      
-
-      
+  {% render 'order-status-tracking' %}
 
 </body>
 </html>

--- a/snippets/order-status-tracking.liquid
+++ b/snippets/order-status-tracking.liquid
@@ -1,0 +1,23 @@
+{% if checkout and order %}
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    try {
+      var orderData = {{ order | json }};
+      var contentIds = orderData.line_items.map(function(item) { return item.product_id; });
+      var payload = {
+        value: orderData.total_price,
+        currency: orderData.currency,
+        content_ids: contentIds
+      };
+      if (typeof fbq === 'function') {
+        fbq('track', 'Purchase', payload);
+      }
+      if (typeof ttq === 'object' && typeof ttq.track === 'function') {
+        ttq.track('CompletePayment', payload);
+      }
+    } catch (e) {
+      console.error('Order tracking error', e);
+    }
+  });
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add snippet to send Facebook and TikTok purchase events on the order status page
- include snippet from `theme.liquid`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b2a87f4fc83248d3dab7fd0804517