### PR TITLE
Fix duplicate AddToCart pixel events

### DIFF
--- a/snippets/product-information.liquid
+++ b/snippets/product-information.liquid
@@ -483,12 +483,8 @@
       if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track(eventName, payload);
     }
 
-    forms.forEach(function(form) {
-      form.addEventListener('submit', function() {
-        var variantId = form.querySelector('[name="id"]').value;
-        sendEvent('AddToCart', variantId);
-      });
-    });
+    // AddToCart pixel events are handled globally in 'site-template'
+    // to avoid duplicate tracking we no longer attach a listener here.
 
     if (forms.length) {
       var initialVariantId = forms[0].querySelector('[name="id"]').value;


### PR DESCRIPTION
## Summary
- drop the AddToCart listener in `product-information.liquid`
- keep the single AddToCart listener from `site-template.liquid`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b3d9132f8832494b9800faf0b8366