### PR TITLE
Fix fbq/ttq stubs to respect existing implementations

### DIFF
--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -3,13 +3,20 @@
 {% endcomment %}
 <script>
 (function() {
-  window.fbq = window.fbq || function(){
-    (window.fbq.callMethod ? window.fbq.callMethod : window.fbq.queue.push).apply(window.fbq, arguments);
-  };
-  window.fbq.queue = window.fbq.queue || [];
+  if (typeof window.fbq !== 'function' || !window.fbq.callMethod) {
+    var fbqQueue = (window.fbq && window.fbq.queue) ? window.fbq.queue : [];
+    window.fbq = function() {
+      (window.fbq.callMethod ? window.fbq.callMethod : fbqQueue.push).apply(window.fbq, arguments);
+    };
+    window.fbq.queue = fbqQueue;
+  }
 
-  if(!window.ttq){
-    window.ttq = {q:[],track:function(){window.ttq.q.push(Array.prototype.slice.call(arguments));}};
+  if (!window.ttq || typeof window.ttq.track !== 'function') {
+    window.ttq = window.ttq || {};
+    window.ttq.q = window.ttq.q || [];
+    window.ttq.track = function() {
+      window.ttq.q.push(Array.prototype.slice.call(arguments));
+    };
   }
 
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- guard initialization of `fbq` and `ttq` objects in tracking snippet

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687b3da844148324bf3d17cc59a65650