### PR TITLE
Remove duplicate ViewContent tracking

### DIFF
--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -20,15 +20,6 @@
   }
 
   document.addEventListener('DOMContentLoaded', function() {
-    {% if request.page_type == 'product' %}
-      var variantId = {{ product.selected_or_first_available_variant.id }};
-      var value = {{ product.selected_or_first_available_variant.price | divided_by: 100.0 | json }};
-      var currency = {{ cart.currency.iso_code | json }};
-      var quantityInput = document.querySelector('form[action^="/cart/add"] [name="quantity"]');
-      var quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
-      fbq('track', 'ViewContent', {content_id: variantId, value: value, currency: currency, quantity: quantity});
-      ttq.track('ViewContent', {content_id: variantId, value: value, currency: currency, quantity: quantity});
-    {% endif %}
 
     document.body.addEventListener('submit', function(e) {
       var form = e.target;


### PR DESCRIPTION
## Summary
- prevent duplicate ViewContent pixel events by removing them from `tracking-pixel.liquid`

## Testing
- `npm test` *(fails: no `package.json` found)*

------
https://chatgpt.com/codex/tasks/task_e_687b41dd65f8832497350a5bbc054b45