### PR TITLE
Centralize AddToCart tracking

### DIFF
--- a/snippets/site-template.liquid
+++ b/snippets/site-template.liquid
@@ -1000,19 +1000,37 @@
     document.body.addEventListener('submit', function (e) {
       var form = e.target.closest('form[data-product-form]');
       if (!form) return;
+
       var variantField = form.querySelector('[name="id"]');
       if (!variantField) return;
       var variantId = variantField.value;
+
       var variant = null;
-      if (window.meta && window.meta.product && Array.isArray(window.meta.product.variants)) {
+
+      var section = form.closest('[id^="shopify-section-"]');
+      if (section) {
+        var jsonEl = section.querySelector('[id^="ProductJson-"]');
+        if (jsonEl) {
+          try {
+            var data = JSON.parse(jsonEl.textContent);
+            if (Array.isArray(data.variants)) {
+              variant = data.variants.find(function(v) { return v.id == Number(variantId); });
+            }
+          } catch (err) {}
+        }
+      }
+
+      if (!variant && window.meta && window.meta.product && Array.isArray(window.meta.product.variants)) {
         variant = window.meta.product.variants.find(function(v) { return v.id == Number(variantId); });
       }
+
       var payload = { content_type: 'product', content_ids: [variantId] };
       if (variant) {
         payload.value = variant.price / 100;
         if (window.Shopify && Shopify.currency && Shopify.currency.active)
           payload.currency = Shopify.currency.active;
       }
+
       if (typeof fbq === 'function') fbq('track', 'AddToCart', payload);
       if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToCart', payload);
     });

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -30,19 +30,22 @@
       ttq.track('ViewContent', {content_id: variantId, value: value, currency: currency, quantity: quantity});
     {% endif %}
 
-    document.body.addEventListener('submit', function(e) {
-      var form = e.target;
-      if (form.matches('form[action^="/cart/add"]')) {
-        var variantInput = form.querySelector('[name="id"]');
-        var quantityInput = form.querySelector('[name="quantity"]');
-        var variantId = variantInput ? variantInput.value : undefined;
-        var quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
-        var currency = {{ cart.currency.iso_code | json }};
-        var value = {{ product.selected_or_first_available_variant.price | divided_by: 100.0 | json }};
-        fbq('track', 'AddToCart', {content_id: variantId, value: value, currency: currency, quantity: quantity});
-        ttq.track('AddToCart', {content_id: variantId, value: value, currency: currency, quantity: quantity});
-      }
-    });
+    /*
+      AddToCart tracking moved to 'site-template' to avoid duplicate events
+      document.body.addEventListener('submit', function(e) {
+        var form = e.target;
+        if (form.matches('form[action^="/cart/add"]')) {
+          var variantInput = form.querySelector('[name="id"]');
+          var quantityInput = form.querySelector('[name="quantity"]');
+          var variantId = variantInput ? variantInput.value : undefined;
+          var quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
+          var currency = {{ cart.currency.iso_code | json }};
+          var value = {{ product.selected_or_first_available_variant.price | divided_by: 100.0 | json }};
+          fbq('track', 'AddToCart', {content_id: variantId, value: value, currency: currency, quantity: quantity});
+          ttq.track('AddToCart', {content_id: variantId, value: value, currency: currency, quantity: quantity});
+        }
+      });
+    */
 
     {% if request.page_type == 'checkout_thank_you' %}
       var currency = {{ checkout.currency | json }};


### PR DESCRIPTION
## Summary
- disable AddToCart code in `tracking-pixel` snippet
- expand AddToCart logic in `site-template` so it reads product JSON from the current section before falling back to `window.meta`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b41dc92e48324aa5e3d97928098e3