### PR TITLE
chore: gate design logs with debug flag

### DIFF
--- a/assets/design-mode.js
+++ b/assets/design-mode.js
@@ -1,9 +1,13 @@
 document.addEventListener('shopify:block:select', (event) => {
-  console.log('shopify:block:select: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:block:select: ', event);
+  }
 });
 
 document.addEventListener('shopify:block:deselect', (event) => {
-  console.log('shopify:block:deselect: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:block:deselect: ', event);
+  }
 });
 
 document.addEventListener('shopify:section:load', (event) => {
@@ -14,24 +18,34 @@ document.addEventListener('shopify:section:load', (event) => {
 });
 
 document.addEventListener('shopify:section:reorder', (event) => {
-  console.log('shopify:section:reorder: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:section:reorder: ', event);
+  }
 });
 
 document.addEventListener('shopify:section:select', (event) => {
-  console.log('shopify:section:select: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:section:select: ', event);
+  }
   $('body').trigger('slideshow:carousel', '.js-vela-slideshow');
   $('body').trigger('carousel:init', '.js-carousel');
   $('body').trigger('vela:countdown', '[data-countdown]');
 });
 
 document.addEventListener('shopify:section:deselect', (event) => {
-  console.log('shopify:section:deselect: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:section:deselect: ', event);
+  }
 });
 
 document.addEventListener('shopify:inspector:activate', (event) => {
-  console.log('shopify:inspector:activate: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:inspector:activate: ', event);
+  }
 });
 
 document.addEventListener('shopify:inspector:deactivate', (event) => {
-  console.log('shopify:inspector:deactivate: ', event);
+  if (window.themeDebug) {
+    console.log('shopify:inspector:deactivate: ', event);
+  }
 });

--- a/snippets/footer-javascript.liquid
+++ b/snippets/footer-javascript.liquid
@@ -35,5 +35,6 @@
 {%- endif-%}
 
 {%- if request.design_mode -%}
+  <script>window.themeDebug = true;</script>
   <script src="{{ 'design-mode.js' | asset_url }}" defer="defer"></script>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- guard design-mode logging with `window.themeDebug`
- enable `window.themeDebug` when in design mode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b4dde21348324a06f47e301f81129