### PR TITLE
fix: load custom fonts locally

### DIFF
--- a/assets/customfont.css
+++ b/assets/customfont.css
@@ -1,7 +1,8 @@
 
 @font-face {
     font-family: 'craftwork grotes';
-    src:url('//www.homad.store/cdn/shop/t/4/assets/CraftworkGrotesk-Bold.woff2?3691') format('woff2');
+    src:url('{{ "CraftworkGrotesk-Bold.woff2" | asset_url }}') format('woff2');
     font-weight: 700;
     font-style: normal;
+    font-display: swap;
 }


### PR DESCRIPTION
## Summary
- load Craftwork font locally instead of remote
- swap fonts as soon as available

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b4ddf51a88324bf65c0ed9425c2d6