### PR TITLE
Add configurable tracking pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ comment out the script tags in that snippet and document the integration.
 
 ## Pixel configuration
 
-Update the IDs inside `snippets/tracking-pixel.liquid` to match your Facebook
-and TikTok pixel accounts. Alternatively you can comment out the script tags in
-that snippet and rely on a Shopify pixel app to inject the tracking code.
+Set your Facebook and TikTok pixel IDs under **Theme settings \> Tracking pixels**.
+The values populate `snippets/tracking-pixel.liquid` automatically. Alternatively you can
+comment out the script tags in that snippet and rely on a Shopify pixel app to
+inject the tracking code.
 
 ## Debugging
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1089,6 +1089,21 @@
     ]
   },
   {
+    "name": "Tracking pixels",
+    "settings": [
+      {
+        "type": "text",
+        "id": "facebook_pixel_id",
+        "label": "Facebook pixel ID"
+      },
+      {
+        "type": "text",
+        "id": "tiktok_pixel_id",
+        "label": "TikTok pixel ID"
+      }
+    ]
+  },
+  {
     "name": "Product card",
     "settings": [
       {

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -12,11 +12,11 @@ n.queue=[];t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];
 s.parentNode.insertBefore(t,s)}(window, document,'script',
 'https://connect.facebook.net/en_US/fbevents.js');
-fbq('init', '1311883059920720');
+fbq('init', '{{ settings.facebook_pixel_id }}');
 fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"
-src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
+src="https://www.facebook.com/tr?id={{ settings.facebook_pixel_id }}&ev=PageView&noscript=1"
 /></noscript>
 <!-- End Meta Pixel Code -->
 <script async src="https://analytics.tiktok.com/i18n/pixel/events.js"></script>
@@ -30,7 +30,7 @@ src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
   for(var i=0;i<ttq.methods.length;i++) ttq.setAndDefer(ttq,ttq.methods[i]);
   ttq.instance=function(t){var e=ttq._i[t]||[];for(var n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e};
   ttq.load=function(e,n){var i='https://analytics.tiktok.com/i18n/pixel/events.js';ttq._i=ttq._i||{};ttq._i[e]=[];ttq._i[e]._u=i;ttq._t=ttq._t||{};ttq._t[e]=+new Date;ttq._o=ttq._o||{};ttq._o[e]=n||{};var o=document.createElement('script');o.type='text/javascript';o.async=true;o.src=i+'?sdkid='+e+'&lib='+t;var a=document.getElementsByTagName('script')[0];a.parentNode.insertBefore(o,a)};
-  ttq.load('D1ST0CRC77UBFMCUIAKG');
+  ttq.load('{{ settings.tiktok_pixel_id }}');
   ttq.page();
 }(window, document, 'ttq');
 </script>
@@ -53,7 +53,7 @@ src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
     };
   }
 
-  ttq.load('D1ST0CRC77UBFMCUIAKG');
+  ttq.load('{{ settings.tiktok_pixel_id }}');
   ttq.page();
 
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- expose Facebook and TikTok pixel IDs as theme settings
- reference these new settings in `tracking-pixel.liquid`
- document how to configure pixel IDs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b6ada47288324b2430caf01ba68d3