### PR TITLE
Embed static Meta and TikTok pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ comment out the script tags in that snippet and document the integration.
 
 ## Pixel configuration
 
-Set your Facebook and TikTok pixel IDs under **Theme settings \> Tracking pixels**.
-The values populate `snippets/tracking-pixel.liquid` automatically. Alternatively you can
-comment out the script tags in that snippet and rely on a Shopify pixel app to
-inject the tracking code.
+The theme embeds Meta and TikTok pixels directly via
+`snippets/tracking-pixel.liquid`. The IDs are hard-coded in that file:
+
+- Meta pixel ID: `1311883059920720`
+- TikTok pixel ID: `D1ST0CRC77UBFMCUIAKG`
+
+Modify the snippet if you need to change these values.
 
 ## Debugging
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1089,21 +1089,6 @@
     ]
   },
   {
-    "name": "Tracking pixels",
-    "settings": [
-      {
-        "type": "text",
-        "id": "facebook_pixel_id",
-        "label": "Facebook pixel ID"
-      },
-      {
-        "type": "text",
-        "id": "tiktok_pixel_id",
-        "label": "TikTok pixel ID"
-      }
-    ]
-  },
-  {
     "name": "Product card",
     "settings": [
       {

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -1,7 +1,3 @@
-{% comment %}
-  Initializes fbq and ttq pixel objects and sends basic ecommerce events.
-  Loads the official Facebook Pixel and TikTok Pixel scripts directly.
-{% endcomment %}
 <!-- Meta Pixel Code -->
 <script>
 !function(f,b,e,v,n,t,s)
@@ -12,69 +8,27 @@ n.queue=[];t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];
 s.parentNode.insertBefore(t,s)}(window, document,'script',
 'https://connect.facebook.net/en_US/fbevents.js');
-fbq('init', '{{ settings.facebook_pixel_id }}');
+fbq('init', '1311883059920720');
 fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"
-src="https://www.facebook.com/tr?id={{ settings.facebook_pixel_id }}&ev=PageView&noscript=1"
+src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
 /></noscript>
 <!-- End Meta Pixel Code -->
-<script async src="https://analytics.tiktok.com/i18n/pixel/events.js"></script>
 <!-- TikTok Pixel Code Start -->
 <script>
-!function (w,d,t){
-  w.TiktokAnalyticsObject=t;
-  var ttq=w[t]=w[t]||[];
-  ttq.methods=['page','track','identify','instances','debug','on','off','once','ready','alias','group','enableCookie','disableCookie'];
-  ttq.setAndDefer=function(t,e){t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}};
-  for(var i=0;i<ttq.methods.length;i++) ttq.setAndDefer(ttq,ttq.methods[i]);
-  ttq.instance=function(t){var e=ttq._i[t]||[];for(var n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e};
-  ttq.load=function(e,n){var i='https://analytics.tiktok.com/i18n/pixel/events.js';ttq._i=ttq._i||{};ttq._i[e]=[];ttq._i[e]._u=i;ttq._t=ttq._t||{};ttq._t[e]=+new Date;ttq._o=ttq._o||{};ttq._o[e]=n||{};var o=document.createElement('script');o.type='text/javascript';o.async=true;o.src=i+'?sdkid='+e+'&lib='+t;var a=document.getElementsByTagName('script')[0];a.parentNode.insertBefore(o,a)};
-  ttq.load('{{ settings.tiktok_pixel_id }}');
+!function (w, d, t) {
+  w.TiktokAnalyticsObject=t;var ttq=w[t]=w[t]||[];ttq.methods=["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie","holdConsent","revokeConsent","grantConsent"],ttq.setAndDefer=function(t,e){t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))} };for(var i=0;i<ttq.methods.length;i++)ttq.setAndDefer(ttq,ttq.methods[i]);ttq.instance=function(t){for(
+var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var r="https://analytics.tiktok.com/i18n/pixel/events.js",o=n&&n.partner;ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=r,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};n=document.createElement("script")
+;n.type="text/javascript",n.async=!0,n.src=r+"?sdkid="+e+"&lib="+t;e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(n,e)};
+
+  ttq.load('D1ST0CRC77UBFMCUIAKG');
   ttq.page();
 }(window, document, 'ttq');
 </script>
 <!-- TikTok Pixel Code End -->
 <script>
-(function() {
-  if (typeof window.fbq !== 'function' || !window.fbq.callMethod) {
-    var fbqQueue = (window.fbq && window.fbq.queue) ? window.fbq.queue : [];
-    window.fbq = function() {
-      (window.fbq.callMethod ? window.fbq.callMethod : fbqQueue.push).apply(window.fbq, arguments);
-    };
-    window.fbq.queue = fbqQueue;
-  }
-
-  if (!window.ttq || typeof window.ttq.track !== 'function') {
-    window.ttq = window.ttq || {};
-    window.ttq.q = window.ttq.q || [];
-    window.ttq.track = function() {
-      window.ttq.q.push(Array.prototype.slice.call(arguments));
-    };
-  }
-
-  ttq.load('{{ settings.tiktok_pixel_id }}');
-  ttq.page();
-
   document.addEventListener('DOMContentLoaded', function() {
-
-    /*
-      AddToCart tracking moved to 'site-template' to avoid duplicate events
-      document.body.addEventListener('submit', function(e) {
-        var form = e.target;
-        if (form.matches('form[action^="/cart/add"]')) {
-          var variantInput = form.querySelector('[name="id"]');
-          var quantityInput = form.querySelector('[name="quantity"]');
-          var variantId = variantInput ? variantInput.value : undefined;
-          var quantity = quantityInput ? parseInt(quantityInput.value, 10) || 1 : 1;
-          var currency = {{ cart.currency.iso_code | json }};
-          var value = {{ product.selected_or_first_available_variant.price | divided_by: 100.0 | json }};
-          fbq('track', 'AddToCart', {content_id: variantId, value: value, currency: currency, quantity: quantity});
-          ttq.track('AddToCart', {content_id: variantId, value: value, currency: currency, quantity: quantity});
-        }
-      });
-    */
-
     {% if request.page_type == 'checkout_thank_you' %}
       var currency = {{ checkout.currency | json }};
       var value = {{ checkout.total_price | money_without_currency | json }};
@@ -93,5 +47,4 @@ src="https://www.facebook.com/tr?id={{ settings.facebook_pixel_id }}&ev=PageView
       ttq.track('Purchase', payload);
     {% endif %}
   });
-})();
 </script>


### PR DESCRIPTION
## Summary
- drop pixel IDs from theme settings
- replace `tracking-pixel.liquid` with static Meta/TikTok pixel scripts
- document new hard-coded pixel IDs

## Testing
- `python3 - <<'PY'
import json,sys
json.load(open('config/settings_schema.json'))
print('valid')
PY`

------
https://chatgpt.com/codex/tasks/task_e_687b7829eaa883249b0c17eccae1a108