### PR TITLE
Add checkout purchase tracking snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ The theme embeds Meta and TikTok pixels directly via
 
 Modify the snippet if you need to change these values.
 
+## Checkout purchase tracking
+
+To track completed orders with Facebook and TikTok pixels,
+include the new `snippets/checkout-purchase-tracking.liquid` snippet in your
+checkout settings:
+
+1. From your Shopify admin, go to **Settings → Checkout**.
+2. Under **Order status page**, paste the contents of
+   `snippets/checkout-purchase-tracking.liquid` into the **Additional scripts**
+   box. Shopify Plus merchants can instead include the snippet in
+   `checkout.liquid`.
+
+The snippet reads the `checkout` object and fires `fbq('track', 'Purchase')`
+and `ttq.track('Purchase')` once the order status page loads.
+
 ## Debugging
 
 Add `debug=true` to the page URL to enable verbose console output from the pixel

--- a/snippets/checkout-purchase-tracking.liquid
+++ b/snippets/checkout-purchase-tracking.liquid
@@ -1,0 +1,19 @@
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var currency = {{ checkout.currency | json }};
+    var value = {{ checkout.subtotal_price | money_without_currency | json }};
+    var content_ids = [
+      {% for line in checkout.line_items %}
+        {{ line.variant_id }}{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+    ];
+    var contents = [
+      {% for line in checkout.line_items %}
+        {id: {{ line.variant_id }}, quantity: {{ line.quantity }}}{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+    ];
+    var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
+    fbq('track', 'Purchase', payload);
+    ttq.track('Purchase', payload);
+  });
+</script>


### PR DESCRIPTION
## Summary
- create a purchase tracking snippet for checkout
- document how to add the snippet in checkout settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b94e664bc832490e73ad029d17273