### PR TITLE
Add editable pixel IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ comment out the script tags in that snippet and document the integration.
 
 ## Pixel configuration
 
-The theme embeds Meta and TikTok pixels directly via
-`snippets/tracking-pixel.liquid`. The IDs are hard-coded in that file:
+The theme embeds Meta and TikTok pixels via `snippets/tracking-pixel.liquid`.
+The pixel IDs can be set from the theme editor under **Tracking pixels**:
 
-- Meta pixel ID: `1311883059920720`
-- TikTok pixel ID: `D1ST0CRC77UBFMCUIAKG`
+- **Meta pixel ID** – value for `settings.meta_pixel_id`
+- **TikTok pixel ID** – value for `settings.tiktok_pixel_id`
 
-Modify the snippet if you need to change these values.
+Edit these fields in your theme settings instead of modifying the snippet
+directly.
 
 ## Debugging
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1567,6 +1567,21 @@
     ]
   },
   {
+    "name": "Tracking pixels",
+    "settings": [
+      {
+        "type": "text",
+        "id": "meta_pixel_id",
+        "label": "Meta pixel ID"
+      },
+      {
+        "type": "text",
+        "id": "tiktok_pixel_id",
+        "label": "TikTok pixel ID"
+      }
+    ]
+  },
+  {
     "name": "Favicon",
     "settings": [
       {

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -8,11 +8,11 @@ n.queue=[];t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];
 s.parentNode.insertBefore(t,s)}(window, document,'script',
 'https://connect.facebook.net/en_US/fbevents.js');
-fbq('init', '1311883059920720');
+fbq('init', {{ settings.meta_pixel_id | json }});
 fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"
-src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
+src="https://www.facebook.com/tr?id={{ settings.meta_pixel_id }}&ev=PageView&noscript=1"
 /></noscript>
 <!-- End Meta Pixel Code -->
 <!-- TikTok Pixel Code Start -->
@@ -22,7 +22,7 @@ src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
 var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var r="https://analytics.tiktok.com/i18n/pixel/events.js",o=n&&n.partner;ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=r,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};n=document.createElement("script")
 ;n.type="text/javascript",n.async=!0,n.src=r+"?sdkid="+e+"&lib="+t;e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(n,e)};
 
-  ttq.load('D1ST0CRC77UBFMCUIAKG');
+  ttq.load({{ settings.tiktok_pixel_id | json }});
   ttq.page();
 }(window, document, 'ttq');
 </script>


### PR DESCRIPTION
## Summary
- add `meta_pixel_id` and `tiktok_pixel_id` settings to the schema
- use those values in `tracking-pixel.liquid`
- document how to edit the pixel IDs from the theme editor

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b951057c083249275fc4d7c5f9ea5