### PR TITLE
Fix pixel configuration and purchase tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,16 @@ comment out the script tags in that snippet and document the integration.
 ## Pixel configuration
 
 The theme embeds Meta and TikTok pixels directly via
-`snippets/tracking-pixel.liquid`. The IDs are hard-coded in that file:
+`snippets/tracking-pixel.liquid`. Their IDs are now configurable from the Theme
+settings screen. Set **Meta pixel ID** and **TikTok pixel ID** under the Pixels
+section when customizing the theme.
 
-- Meta pixel ID: `1311883059920720`
-- TikTok pixel ID: `D1ST0CRC77UBFMCUIAKG`
+To record purchases on the order status page, copy the contents of
+`snippets/pixel-checkout-script.liquid` into Shopify’s **Additional scripts**
+field (or `checkout.liquid` if you are on Shopify Plus).
 
-Modify the snippet if you need to change these values.
+The purchase value sent to the pixels uses `checkout.subtotal_price`, so
+shipping and taxes are excluded.
 
 ## Debugging
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1567,6 +1567,21 @@
     ]
   },
   {
+    "name": "Pixels",
+    "settings": [
+      {
+        "type": "text",
+        "id": "meta_pixel_id",
+        "label": "Meta Pixel ID"
+      },
+      {
+        "type": "text",
+        "id": "tiktok_pixel_id",
+        "label": "TikTok Pixel ID"
+      }
+    ]
+  },
+  {
     "name": "Favicon",
     "settings": [
       {

--- a/snippets/pixel-checkout-script.liquid
+++ b/snippets/pixel-checkout-script.liquid
@@ -1,0 +1,19 @@
+{% if first_time_accessed %}
+<script>
+  var currency = {{ checkout.currency | json }};
+  var value = {{ checkout.subtotal_price | money_without_currency | json }};
+  var content_ids = [
+    {% for line in checkout.line_items %}
+      {{ line.variant_id }}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  ];
+  var contents = [
+    {% for line in checkout.line_items %}
+      {id: {{ line.variant_id }}, quantity: {{ line.quantity }}}{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  ];
+  var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
+  fbq('track', 'Purchase', payload);
+  ttq.track('Purchase', payload);
+</script>
+{% endif %}

--- a/snippets/site-template.liquid
+++ b/snippets/site-template.liquid
@@ -1024,9 +1024,13 @@
         variant = window.meta.product.variants.find(function(v) { return v.id == Number(variantId); });
       }
 
+      var qtyField = form.querySelector('[name="quantity"]');
+      var quantity = qtyField ? parseInt(qtyField.value, 10) || 1 : 1;
+
       var payload = { content_type: 'product', content_ids: [variantId] };
       if (variant) {
-        payload.value = variant.price / 100;
+        payload.value = (variant.price / 100) * quantity;
+        payload.contents = [{ id: variantId, quantity: quantity }];
         if (window.Shopify && Shopify.currency && Shopify.currency.active)
           payload.currency = Shopify.currency.active;
       }

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -8,11 +8,11 @@ n.queue=[];t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];
 s.parentNode.insertBefore(t,s)}(window, document,'script',
 'https://connect.facebook.net/en_US/fbevents.js');
-fbq('init', '1311883059920720');
+fbq('init', {{ settings.meta_pixel_id | json }});
 fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"
-src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
+src="https://www.facebook.com/tr?id={{ settings.meta_pixel_id }}&ev=PageView&noscript=1"
 /></noscript>
 <!-- End Meta Pixel Code -->
 <!-- TikTok Pixel Code Start -->
@@ -22,7 +22,7 @@ src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"
 var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var r="https://analytics.tiktok.com/i18n/pixel/events.js",o=n&&n.partner;ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=r,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};n=document.createElement("script")
 ;n.type="text/javascript",n.async=!0,n.src=r+"?sdkid="+e+"&lib="+t;e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(n,e)};
 
-  ttq.load('D1ST0CRC77UBFMCUIAKG');
+  ttq.load({{ settings.tiktok_pixel_id | json }});
   ttq.page();
 }(window, document, 'ttq');
 </script>
@@ -31,7 +31,7 @@ var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n
   document.addEventListener('DOMContentLoaded', function() {
     {% if request.page_type == 'checkout_thank_you' %}
       var currency = {{ checkout.currency | json }};
-      var value = {{ checkout.total_price | money_without_currency | json }};
+      var value = {{ checkout.subtotal_price | money_without_currency | json }};
       var content_ids = [
         {% for line in checkout.line_items %}
           {{ line.variant_id }}{% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
## Summary
- record AddToCart value using quantity
- add meta and TikTok pixel ID settings
- use subtotal for purchase value and load IDs from settings
- add snippet for checkout purchase tracking
- document pixel setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b7fd71af0832489ef3102ae73f583