### PR TITLE
Add wishlist, search and payment info pixel events

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ checkout settings:
 The snippet reads the `checkout` object and fires `fbq('track', 'Purchase')`
 and `ttq.track('Purchase')` once the order status page loads.
 
+## Checkout payment info tracking
+
+To track when a customer submits their payment details, include
+`snippets/checkout-paymentinfo-tracking.liquid` in your checkout code. Paste it
+into the **Additional scripts** box or, for Shopify Plus stores, add it to
+`checkout.liquid`. The snippet fires `fbq('track', 'AddPaymentInfo')` and
+`ttq.track('AddPaymentInfo')` when the payment method form is submitted.
+
 ## Debugging
 
 Add `debug=true` to the page URL to enable verbose console output from the pixel

--- a/assets/wishlist.js
+++ b/assets/wishlist.js
@@ -99,6 +99,11 @@ vela.wishlist = {
         // Update wishlist item count and button status
         vela.wishlist.updateWishlist();
     },
+    trackAddToWishlist: (handle) => {
+        const payload = { content_type: 'product', content_ids: [handle] };
+        if (typeof fbq === 'function') fbq('track', 'AddToWishlist', payload);
+        if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToWishlist', payload);
+    },
     buttons: () => {
         if (jQuery && $) {
             $(document).on('click', vela.wishlist.selectors.button, (e) => {
@@ -124,6 +129,7 @@ vela.wishlist = {
                         const addItem = vela.wishlist.addItem(button.dataset.productHandle);
                         if (addItem) {
                             vela.wishlist.updateButton(button, true);
+                            vela.wishlist.trackAddToWishlist(button.dataset.productHandle);
 
                             if (page) {
                                 vela.wishlist.initPage();

--- a/snippets/checkout-paymentinfo-tracking.liquid
+++ b/snippets/checkout-paymentinfo-tracking.liquid
@@ -1,0 +1,13 @@
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (window.Shopify && Shopify.Checkout && Shopify.Checkout.step === 'payment_method') {
+      var form = document.querySelector('form[action*="/checkouts/"]');
+      if (form) {
+        form.addEventListener('submit', function() {
+          if (typeof fbq === 'function') fbq('track', 'AddPaymentInfo');
+          if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddPaymentInfo');
+        });
+      }
+    }
+  });
+</script>

--- a/snippets/site-template.liquid
+++ b/snippets/site-template.liquid
@@ -1049,3 +1049,19 @@
     });
   });
 </script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.body.addEventListener('submit', function (e) {
+      var form = e.target.closest('form[role="search"]');
+      if (!form) return;
+
+      var input = form.querySelector('input[name="q"]');
+      if (!input) return;
+
+      var query = input.value;
+      var payload = { search_string: query };
+      if (typeof fbq === 'function') fbq('track', 'Search', payload);
+      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('Search', payload);
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- add script for AddPaymentInfo tracking
- track AddToWishlist events in `wishlist.js`
- send `Search` event from site-template
- document the new payment info snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b9c8edcd0832480d7a10aa770d330