### PR TITLE
Add query parameter debug flag

### DIFF
--- a/snippets/footer-javascript.liquid
+++ b/snippets/footer-javascript.liquid
@@ -1,4 +1,9 @@
 {% comment %} Footer JS {% endcomment %}
+<script>
+  if (new URLSearchParams(window.location.search).has('debug')) {
+    window.themeDebug = true;
+  }
+</script>
 <script src="{{ 'shopify_common.js' | shopify_asset_url }}" defer="defer"></script>
 <script src="{{ 'global.min.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'bootstrap.min.js' | asset_url }}" defer="defer"></script>


### PR DESCRIPTION
## Summary
- allow enabling `window.themeDebug` by visiting pages with `?debug`
- keep design-mode logging controlled by `window.themeDebug`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ba4e5c17c832485a9f7107f1080c6