### PR TITLE
Fix checkout purchase value variable

### DIFF
--- a/snippets/checkout-purchase-tracking.liquid
+++ b/snippets/checkout-purchase-tracking.liquid
@@ -1,7 +1,7 @@
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     var currency = {{ checkout.currency | json }};
-    var value = {{ checkout.subtotal_price | money_without_currency | json }};
+    var value = {{ checkout.total_price | money_without_currency | json }};
     var content_ids = [
       {% for line in checkout.line_items %}
         {{ line.variant_id }}{% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
## Summary
- use `checkout.total_price` instead of `checkout.subtotal_price` in purchase tracking snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ba4e420fc8324a9735f7e006e621c