### PR TITLE
Fix purchase tracking page_type

### DIFF
--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -29,7 +29,7 @@ var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n
 <!-- TikTok Pixel Code End -->
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    {% if request.page_type == 'checkout_thank_you' %}
+    {% if request.page_type == 'thank_you' %}
       var currency = {{ checkout.currency | json }};
       var value = {{ checkout.total_price | money_without_currency | json }};
       var content_ids = [


### PR DESCRIPTION
## Summary
- update the pixel tracking snippet so it fires on the correct thank-you page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c5d05b4ec832480b55b54cc8ce46b