### PR TITLE
Fix Purchase tracking script checks

### DIFF
--- a/snippets/checkout-purchase-tracking.liquid
+++ b/snippets/checkout-purchase-tracking.liquid
@@ -13,7 +13,7 @@
       {% endfor %}
     ];
     var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
-    fbq('track', 'Purchase', payload);
-    ttq.track('Purchase', payload);
+    if (typeof fbq === 'function') fbq('track', 'Purchase', payload);
+    if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('Purchase', payload);
   });
 </script>


### PR DESCRIPTION
## Summary
- check that `fbq` is a function before calling `fbq('track', 'Purchase', payload)`
- check that `ttq` has a callable `track` method before using it

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687c6295cacc83248a501c57e5d236b0