### PR TITLE
Insert Facebook and TikTok pixel scripts directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # homad-theme-review
 Shopify Aceno theme for pixel tracking and cart debugging.
 
-The `snippets/tracking-pixel.liquid` file now contains only the event tracking
-logic. Load the Facebook and TikTok pixel libraries through Shopify's pixel
-settings or a dedicated app. If you would rather include the libraries directly
-in the theme, paste the standard scripts into that snippet above the event
-handlers.
+The `snippets/tracking-pixel.liquid` file includes the Facebook and TikTok
+pixel scripts directly. If you need to change the pixel IDs, edit that snippet
+and replace them with your own before the event handlers.
 
 ## Installation
 
@@ -18,15 +16,10 @@ handlers.
 
 ## Pixel configuration
 
-The theme fires Meta and TikTok events via `snippets/tracking-pixel.liquid`.
-Load the pixel scripts through Shopify or an app, then set the IDs under
-**Tracking pixels**:
-
-- **Meta pixel ID** – value for `settings.meta_pixel_id`
-- **TikTok pixel ID** – value for `settings.tiktok_pixel_id`
-
-Edit these fields in your theme settings instead of modifying the snippet
-directly. Leaving an ID blank disables events for that pixel.
+The theme fires Meta and TikTok events via `snippets/tracking-pixel.liquid`,
+which already contains example pixel scripts. To use your own IDs, open the
+snippet and replace the sample values with your pixel IDs. No Shopify apps or
+theme settings are required.
 
 ## Checkout purchase tracking
 

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -1,5 +1,27 @@
-{% if settings.meta_pixel_id != blank %}
-{% endif %}
+<!-- Meta Pixel Code -->
+<script>
+!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
+fbq('init', '1311883059920720');
+fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"/></noscript>
+<!-- End Meta Pixel Code -->
+
+<!-- TikTok Pixel Code Start -->
+<script>
+!function (w, d, t) {
+  w.TiktokAnalyticsObject=t;var ttq=w[t]=w[t]||[];ttq.methods=["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie","holdConsent","revokeConsent","grantConsent"],ttq.setAndDefer=function(t,e){t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}};for(var i=0;i<ttq.methods.length;i++)ttq.setAndDefer(ttq,ttq.methods[i]);ttq.instance=function(t){for(
+var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var r="https://analytics.tiktok.com/i18n/pixel/events.js",o=n&&n.partner;ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=r,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};n=document.createElement("script")
+;n.type="text/javascript",n.async=!0,n.src=r+"?sdkid="+e+"&lib="+t;e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(n,e)};
+
+
+  ttq.load('D1ST0CRC77UBFMCUIAKG');
+  ttq.page();
+}(window, document, 'ttq');
+</script>
+<!-- TikTok Pixel Code End -->
+
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     {% if request.page_type == 'thank_you' %}
@@ -16,12 +38,8 @@
         {% endfor %}
       ];
       var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
-      {% if settings.meta_pixel_id != blank %}
       fbq('track', 'Purchase', payload);
-      {% endif %}
-      {% if settings.tiktok_pixel_id != blank %}
       ttq.track('Purchase', payload);
-      {% endif %}
     {% endif %}
   });
 </script>


### PR DESCRIPTION
## Summary
- embed Meta and TikTok pixel code directly in `tracking-pixel.liquid`
- remove references to Shopify's pixel settings in the README
- describe manual editing of pixel IDs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687c66231f188324a0dfbd81ab1a365e