### PR TITLE
Remove pixel scripts from theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # homad-theme-review
 Shopify Aceno theme for pixel tracking and cart debugging.
 
-The `snippets/tracking-pixel.liquid` file includes the Facebook and TikTok
-pixel scripts directly. If you need to change the pixel IDs, edit that snippet
-and replace them with your own before the event handlers.
+This theme no longer embeds pixel scripts directly.
+Use Shopify **Customer Events** to manage your tracking pixels without editing theme files.
 
 ## Installation
 
@@ -16,10 +15,13 @@ and replace them with your own before the event handlers.
 
 ## Pixel configuration
 
-The theme fires Meta and TikTok events via `snippets/tracking-pixel.liquid`,
-which already contains example pixel scripts. To use your own IDs, open the
-snippet and replace the sample values with your pixel IDs. No Shopify apps or
-theme settings are required.
+Use Shopify **Customer Events** to create and manage your own pixels.
+1. In the admin, go to **Settings → Customer events**.
+2. Click **Create custom pixel** and paste your pixel code.
+3. Subscribe to events such as `page_viewed` and `checkout_completed`.
+4. Save and enable the pixel.
+
+After enabling, place a test order and verify events with Facebook Pixel Helper or TikTok Pixel Helper.
 
 ## Checkout purchase tracking
 

--- a/assets/wishlist.js
+++ b/assets/wishlist.js
@@ -101,8 +101,6 @@ vela.wishlist = {
     },
     trackAddToWishlist: (handle) => {
         const payload = { content_type: 'product', content_ids: [handle] };
-        if (typeof fbq === 'function') fbq('track', 'AddToWishlist', payload);
-        if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToWishlist', payload);
     },
     buttons: () => {
         if (jQuery && $) {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -40,7 +40,6 @@
 
       
                 <script>document.documentElement.className = document.documentElement.className.replace('no-js', 'js');</script>
-                {% render 'tracking-pixel' %}
         </head>
 	<body id="{{ page_title | handle }}" class="{% if customer %}customer-logged-in {% endif %}template-{{ request.page_type | handle }} {{ template.suffix }} gx-3 gx-md-4">
 		{%- if settings.preloading -%}

--- a/snippets/checkout-paymentinfo-tracking.liquid
+++ b/snippets/checkout-paymentinfo-tracking.liquid
@@ -4,8 +4,6 @@
       var form = document.querySelector('form[action*="/checkouts/"]');
       if (form) {
         form.addEventListener('submit', function() {
-          if (typeof fbq === 'function') fbq('track', 'AddPaymentInfo');
-          if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddPaymentInfo');
         });
       }
     }

--- a/snippets/checkout-purchase-tracking.liquid
+++ b/snippets/checkout-purchase-tracking.liquid
@@ -13,7 +13,5 @@
       {% endfor %}
     ];
     var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
-    if (typeof fbq === 'function') fbq('track', 'Purchase', payload);
-    if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('Purchase', payload);
   });
 </script>

--- a/snippets/product-information.liquid
+++ b/snippets/product-information.liquid
@@ -479,8 +479,6 @@
         if (window.Shopify && Shopify.currency && Shopify.currency.active)
           payload.currency = Shopify.currency.active;
       }
-      if (typeof fbq === 'function') fbq('track', eventName, payload);
-      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track(eventName, payload);
     }
 
     // AddToCart pixel events are handled globally in 'site-template'

--- a/snippets/site-template.liquid
+++ b/snippets/site-template.liquid
@@ -1050,8 +1050,6 @@
               payload.value = variant.price / 100 * qty;
             }
 
-            if (typeof fbq === 'function') fbq('track', 'AddToCart', payload);
-            if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToCart', payload);
           });
       }, 500);
     });
@@ -1064,8 +1062,6 @@
       if (!form) return;
 
       if (form.querySelector('[name="checkout"]')) {
-        if (typeof fbq === 'function') fbq('track', 'InitiateCheckout');
-        if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('InitiateCheckout');
       }
     });
   });
@@ -1080,9 +1076,6 @@
       if (!input) return;
 
       var query = input.value;
-      var payload = { search_string: query };
-      if (typeof fbq === 'function') fbq('track', 'Search', payload);
-      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('Search', payload);
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- clean up theme layout by removing old `tracking-pixel` snippet include
- strip `fbq` and `ttq` calls from wishlist and tracking snippets
- document how to add tracking with Customer Events instead of editing theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c8daf0df08324ab3189892c9c9052