### PR TITLE
Centralize pixel events via Customer Events

### DIFF
--- a/assets/customer-events.js
+++ b/assets/customer-events.js
@@ -1,0 +1,70 @@
+(function(){
+  function fbTrack(ev, payload){
+    if(typeof fbq === 'function') fbq('track', ev, payload);
+  }
+  function ttTrack(ev, payload){
+    if(typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track(ev, payload);
+  }
+  function ttPage(){
+    if(typeof ttq === 'object' && typeof ttq.page === 'function') ttq.page();
+  }
+
+  if(window.analytics && typeof analytics.subscribe === 'function'){
+    analytics.subscribe('page_viewed', function(){
+      fbTrack('PageView');
+      ttPage();
+    });
+
+    analytics.subscribe('view_content', function(event){
+      fbTrack('ViewContent', event.data);
+      ttTrack('ViewContent', event.data);
+    });
+
+    analytics.subscribe('add_to_cart', function(event){
+      fbTrack('AddToCart', event.data);
+      ttTrack('AddToCart', event.data);
+    });
+
+    analytics.subscribe('initiate_checkout', function(){
+      fbTrack('InitiateCheckout');
+      ttTrack('InitiateCheckout');
+    });
+
+    analytics.subscribe('search', function(event){
+      fbTrack('Search', event.data);
+      ttTrack('Search', event.data);
+    });
+
+    analytics.subscribe('add_to_wishlist', function(event){
+      fbTrack('AddToWishlist', event.data);
+      ttTrack('AddToWishlist', event.data);
+    });
+
+    analytics.subscribe('add_payment_info', function(){
+      fbTrack('AddPaymentInfo');
+      ttTrack('AddPaymentInfo');
+    });
+
+    analytics.subscribe('purchase', function(event){
+      fbTrack('Purchase', event.data);
+      ttTrack('Purchase', event.data);
+    });
+
+    analytics.subscribe('lead', function(){
+      fbTrack('Lead');
+      ttTrack('Lead');
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    document.body.addEventListener('submit', function(e){
+      var form = e.target.closest('form');
+      if(!form) return;
+      if(form.matches('.contact-form, form[action*="contact"], form[action*="subscribe"]')){
+        if(window.analytics && typeof analytics.publish === 'function'){
+          analytics.publish('lead');
+        }
+      }
+    });
+  });
+})();

--- a/assets/wishlist.js
+++ b/assets/wishlist.js
@@ -100,9 +100,9 @@ vela.wishlist = {
         vela.wishlist.updateWishlist();
     },
     trackAddToWishlist: (handle) => {
-        const payload = { content_type: 'product', content_ids: [handle] };
-        if (typeof fbq === 'function') fbq('track', 'AddToWishlist', payload);
-        if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToWishlist', payload);
+        if (window.analytics && typeof analytics.publish === 'function') {
+            analytics.publish('add_to_wishlist', { handle: handle });
+        }
     },
     buttons: () => {
         if (jQuery && $) {

--- a/snippets/checkout-paymentinfo-tracking.liquid
+++ b/snippets/checkout-paymentinfo-tracking.liquid
@@ -4,8 +4,9 @@
       var form = document.querySelector('form[action*="/checkouts/"]');
       if (form) {
         form.addEventListener('submit', function() {
-          if (typeof fbq === 'function') fbq('track', 'AddPaymentInfo');
-          if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddPaymentInfo');
+          if (window.analytics && typeof analytics.publish === 'function') {
+            analytics.publish('add_payment_info');
+          }
         });
       }
     }

--- a/snippets/checkout-purchase-tracking.liquid
+++ b/snippets/checkout-purchase-tracking.liquid
@@ -13,7 +13,8 @@
       {% endfor %}
     ];
     var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
-    if (typeof fbq === 'function') fbq('track', 'Purchase', payload);
-    if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('Purchase', payload);
+    if (window.analytics && typeof analytics.publish === 'function') {
+      analytics.publish('purchase', payload);
+    }
   });
 </script>

--- a/snippets/product-information.liquid
+++ b/snippets/product-information.liquid
@@ -479,8 +479,9 @@
         if (window.Shopify && Shopify.currency && Shopify.currency.active)
           payload.currency = Shopify.currency.active;
       }
-      if (typeof fbq === 'function') fbq('track', eventName, payload);
-      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track(eventName, payload);
+      if (window.analytics && typeof analytics.publish === 'function') {
+        analytics.publish(eventName.toLowerCase(), payload);
+      }
     }
 
     // AddToCart pixel events are handled globally in 'site-template'
@@ -488,7 +489,7 @@
 
     if (forms.length) {
       var initialVariantId = forms[0].querySelector('[name="id"]').value;
-      sendEvent('ViewContent', initialVariantId);
+      sendEvent('view_content', initialVariantId);
     }
   });
 </script>

--- a/snippets/site-template.liquid
+++ b/snippets/site-template.liquid
@@ -1050,8 +1050,9 @@
               payload.value = variant.price / 100 * qty;
             }
 
-            if (typeof fbq === 'function') fbq('track', 'AddToCart', payload);
-            if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('AddToCart', payload);
+            if (window.analytics && typeof analytics.publish === 'function') {
+              analytics.publish('add_to_cart', payload);
+            }
           });
       }, 500);
     });
@@ -1064,8 +1065,9 @@
       if (!form) return;
 
       if (form.querySelector('[name="checkout"]')) {
-        if (typeof fbq === 'function') fbq('track', 'InitiateCheckout');
-        if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('InitiateCheckout');
+        if (window.analytics && typeof analytics.publish === 'function') {
+          analytics.publish('initiate_checkout');
+        }
       }
     });
   });
@@ -1081,8 +1083,9 @@
 
       var query = input.value;
       var payload = { search_string: query };
-      if (typeof fbq === 'function') fbq('track', 'Search', payload);
-      if (typeof ttq === 'object' && typeof ttq.track === 'function') ttq.track('Search', payload);
+      if (window.analytics && typeof analytics.publish === 'function') {
+        analytics.publish('search', payload);
+      }
     });
   });
 </script>

--- a/snippets/tracking-pixel.liquid
+++ b/snippets/tracking-pixel.liquid
@@ -3,9 +3,7 @@
 !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
 fbq('init', '1311883059920720');
-fbq('track', 'PageView');
 </script>
-<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1311883059920720&ev=PageView&noscript=1"/></noscript>
 <!-- End Meta Pixel Code -->
 
 <!-- TikTok Pixel Code Start -->
@@ -17,29 +15,7 @@ var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n
 
 
   ttq.load('D1ST0CRC77UBFMCUIAKG');
-  ttq.page();
 }(window, document, 'ttq');
 </script>
 <!-- TikTok Pixel Code End -->
 
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    {% if request.page_type == 'thank_you' %}
-      var currency = {{ checkout.currency | json }};
-      var value = {{ checkout.total_price | money_without_currency | json }};
-      var content_ids = [
-        {% for line in checkout.line_items %}
-          {{ line.variant_id }}{% unless forloop.last %},{% endunless %}
-        {% endfor %}
-      ];
-      var contents = [
-        {% for line in checkout.line_items %}
-          {id: {{ line.variant_id }}, quantity: {{ line.quantity }}}{% unless forloop.last %},{% endunless %}
-        {% endfor %}
-      ];
-      var payload = {content_ids: content_ids, contents: contents, value: value, currency: currency};
-      fbq('track', 'Purchase', payload);
-      ttq.track('Purchase', payload);
-    {% endif %}
-  });
-</script>


### PR DESCRIPTION
## Summary
- remove direct pixel events from `tracking-pixel.liquid`
- publish custom events in site and product snippets
- forward wishlist actions through `analytics.publish`
- update checkout tracking snippets to use `analytics.publish`
- add `customer-events.js` script to subscribe to events and send to Meta and TikTok pixels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c9cf20b548324886023231285a859