### PR TITLE
Update README pixel instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,5 @@
 # homad-theme-review
-Shopify Aceno theme for pixel tracking and cart debugging.
-
-The `snippets/tracking-pixel.liquid` file includes the Facebook and TikTok
-pixel scripts directly. If you need to change the pixel IDs, edit that snippet
-and replace them with your own before the event handlers.
-
-## Installation
-
-1. Clone this repository and upload the contents to a new theme in your Shopify
-   store.
-2. To work locally with [Shopify CLI](https://shopify.dev/themes/tools/cli), run
-   `shopify theme serve` in the project directory.
-3. When you are ready to publish, use `shopify theme push` to deploy the theme
-   to your store.
-
-## Pixel configuration
-
-The theme fires Meta and TikTok events via `snippets/tracking-pixel.liquid`,
-which already contains example pixel scripts. To use your own IDs, open the
-snippet and replace the sample values with your pixel IDs. No Shopify apps or
-theme settings are required.
-
-## Checkout purchase tracking
-
-To track completed orders with Facebook and TikTok pixels,
-include the new `snippets/checkout-purchase-tracking.liquid` snippet in your
-checkout settings:
-
-1. From your Shopify admin, go to **Settings → Checkout**.
-2. Under **Order status page**, paste the contents of
-   `snippets/checkout-purchase-tracking.liquid` into the **Additional scripts**
-   box. Shopify Plus merchants can instead include the snippet in
-   `checkout.liquid`.
-
-The snippet reads the `checkout` object and fires `fbq('track', 'Purchase')`
-and `ttq.track('Purchase')` once the order status page loads.
-
-## Checkout payment info tracking
-
-To track when a customer submits their payment details, include
-`snippets/checkout-paymentinfo-tracking.liquid` in your checkout code. Paste it
-into the **Additional scripts** box or, for Shopify Plus stores, add it to
-`checkout.liquid`. The snippet fires `fbq('track', 'AddPaymentInfo')` and
-`ttq.track('AddPaymentInfo')` when the payment method form is submitted.
+Pixel tracking should be set up via Shopify's customer events or pixel manager.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary
- remove references to Facebook/TikTok tracking snippets
- add a note on configuring pixels via Shopify's built-in tools

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cba1958bc832489f8ae5e893040af