### PR TITLE
Fix default FontAwesome setting

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -387,7 +387,7 @@
         "id": "font_icon",
         "label": "Use font icon awesome v4.7",
         "info": "[Find icon](https:\/\/fontawesome.com\/v4.7\/icons\/)",
-        "default": false
+        "default": true
       },
       {
         "type": "header",


### PR DESCRIPTION
## Summary
- turn on Font Awesome icons by default so icons display automatically

## Testing
- `grep -n "font_icon" -n config/settings_schema.json`

------
https://chatgpt.com/codex/tasks/task_e_687d0581fb488324b86d6bdc017ef01e