### PR TITLE
Add svg snippet to password layout

### DIFF
--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -76,6 +76,7 @@
 		<main id="MainContent" class="password-main">
 			{{ content_for_layout }}
 		</main>
-		{% include 'footer-javascript' %}
-	</body>
+                {% include 'footer-javascript' %}
+                {% render 'svg' %}
+        </body>
 </html>


### PR DESCRIPTION
## Summary
- enable icon definitions on password page by rendering 'svg' snippet

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687de42d387c8324a5a7c87221632bed