### PR TITLE
Connect wishlist with Ultimate datalayer

### DIFF
--- a/assets/wishlist.js
+++ b/assets/wishlist.js
@@ -100,6 +100,33 @@ vela.wishlist = {
         vela.wishlist.updateWishlist();
     },
     trackAddToWishlist: (handle) => {
+        if (!handle || !window.ultimateShopifyDataLayer ||
+            typeof window.ultimateShopifyDataLayer.ecommerceDataLayer !== 'function') {
+            return;
+        }
+
+        fetch(`${window.Shopify.routes.root}products/${handle}.json`)
+            .then((res) => res.json())
+            .then((result) => {
+                const data = result.product;
+                if (data) {
+                    const variant = data.variants[0];
+                    const dataLayerData = {
+                        product_id: data.id,
+                        variant_id: variant.id,
+                        product_title: data.title,
+                        quantity: 1,
+                        final_price: parseFloat(variant.price) * 100,
+                        total_discount: 0,
+                        product_type: data.product_type,
+                        vendor: data.vendor,
+                        variant_title: (variant.title !== 'Default Title') ? variant.title : undefined,
+                        sku: variant.sku
+                    };
+                    window.ultimateShopifyDataLayer.ecommerceDataLayer('add_to_wishlist', { items: [dataLayerData] });
+                }
+            })
+            .catch(() => {});
     },
     buttons: () => {
         if (jQuery && $) {

--- a/snippets/onboarding-featured-products-deal.liquid
+++ b/snippets/onboarding-featured-products-deal.liquid
@@ -119,7 +119,7 @@
 								</a>
 							{%- endif -%}
 							{%- if settings.product_wishlist and  settings.product_card_wishlist -%}
-								<button type="button" aria-label="{{ 'products.product.wishlist' | t }}" class="btn--wishlist btn--action border rounded-circle mb-2" data-product-handle="{{ product.handle }}" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-title="{{ 'products.product.add_to_wishlist' | t }}">
+                                                                <button type="button" aria-label="{{ 'products.product.wishlist' | t }}" class="btn--wishlist js-btn-wishlist btn--action border rounded-circle mb-2" data-product-handle="{{ product.handle }}" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-title="{{ 'products.product.add_to_wishlist' | t }}">
 									{% render 'icons', icon: 'heart', attr: 'width="14" height="14"' %}
 								</button>
 							{%- endif -%}

--- a/snippets/onboarding-featured-products.liquid
+++ b/snippets/onboarding-featured-products.liquid
@@ -74,7 +74,7 @@
 							{%- endif -%}
 							<div class="shop-action position-absolute top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">
 								{%- if settings.product_wishlist and  settings.product_card_wishlist -%}
-									<button class="btn btn--action btn--wishlist show-tooltip" type="button">				
+                                                                        <button class="btn btn--action btn--wishlist js-btn-wishlist show-tooltip" type="button">
 										{% render 'icons', icon: 'heart', class: 'heart', attr: 'width="18" height="18"' %}
 										<div class="tooltip bs-tooltip-{% if settings.badge_position == 'start' %}start{% else %}end{% endif %}" role="tooltip">
 											<div class="tooltip-arrow"></div>
@@ -195,7 +195,7 @@
 							{%- endif -%}
 							<div class="shop-action position-absolute top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">
 								{%- if settings.product_wishlist and  settings.product_card_wishlist -%}
-									<a class="btn btn--wishlist show-tooltip">				
+                                                                        <a class="btn btn--wishlist js-btn-wishlist show-tooltip">
 										{% render 'icons', icon: 'heart', class: 'heart', attr: 'width="18" height="18"' %}
 										<div class="tooltip bs-tooltip-{% if settings.badge_position == 'start' %}start{% else %}end{% endif %}" role="tooltip">
 											<div class="tooltip-arrow"></div>
@@ -348,7 +348,7 @@
 									</a>
 								{%- endif -%}
 								{%- if settings.product_wishlist and  settings.product_card_wishlist -%}
-									<a class="btn btn--action btn--wishlist show-tooltip">				
+                                                                        <a class="btn btn--action btn--wishlist js-btn-wishlist show-tooltip">
 										{% render 'icons', icon: 'heart', class: 'heart', attr: 'width="18" height="18"' %}
 										<div class="tooltip bs-tooltip-top" role="tooltip">
 											<div class="tooltip-arrow"></div>
@@ -433,7 +433,7 @@
 							{%- endif -%}
 							<div class="shop-action position-absolute top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">
 								{%- if settings.product_wishlist and  settings.product_card_wishlist -%}
-									<a class="btn btn--wishlist show-tooltip top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">				
+                                                                        <a class="btn btn--wishlist js-btn-wishlist show-tooltip top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">
 										{% render 'icons', icon: 'heart', class: 'heart', attr: 'width="18" height="18"' %}
 										<div class="tooltip bs-tooltip-{% if settings.badge_position == 'start' %}start{% else %}end{% endif %}" role="tooltip">
 											<div class="tooltip-arrow"></div>
@@ -553,7 +553,7 @@
 								<div class="product-card__countdown d-flex position-absolute bottom-0 start-50 translate-middle-x bg-white rounded-pill py-1 px-3" data-countdown="{{ countdownTime }}"></div>
 							{%- endif -%}
 							{%- if settings.product_wishlist and  settings.product_card_wishlist -%}
-								<button type="button" aria-label="{{ 'products.product.wishlist' | t }}" class="btn--wishlist position-absolute show-tooltip top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">				
+                                                                <button type="button" aria-label="{{ 'products.product.wishlist' | t }}" class="btn--wishlist js-btn-wishlist position-absolute show-tooltip top-0 {% if settings.badge_position == 'start' %}end-0{% else %}start-0{% endif %}">
 									{% render 'icons', icon: 'heart', class: 'heart', attr: 'width="18" height="18"' %}
 									<div class="tooltip bs-tooltip-{% if settings.badge_position == 'start' %}start{% else %}end{% endif %}" role="tooltip">
 										<div class="tooltip-arrow"></div>

--- a/snippets/ultimate-datalayer.liquid
+++ b/snippets/ultimate-datalayer.liquid
@@ -24,8 +24,8 @@
 
           // add to wishlist selectors
           this.addToWishListSelectors = {
-            'addWishListIcon': '',
-            'gridItemSelector': '',
+            'addWishListIcon': '.js-btn-wishlist',
+            'gridItemSelector': '.product-card',
             'productLinkSelector': 'a[href*="/products/"]'
           }
 
@@ -971,7 +971,7 @@
 
       document.addEventListener('DOMContentLoaded', function() {
         try{
-          new Ultimate_Shopify_DataLayer();
+          window.ultimateShopifyDataLayer = new Ultimate_Shopify_DataLayer();
         }catch(error) {
           console.log(error);
         }


### PR DESCRIPTION
## Summary
- wire wishlist buttons to the Ultimate datalayer
- expose the datalayer instance globally so other scripts can use it
- implement JS helper to send add_to_wishlist event
- ensure onboarding snippets use the standard wishlist selector

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e02132ed8832485ceea9690cbfa42